### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=0.1
 author=Jesper Henriksen <https://github.com/ttytyper>
 maintainer=Jesper Henriksen <https://github.com/ttytyper>
 sentence=Another library for the ADXL362 motion sensor
+paragraph=
 url=https://github.com/ttytyper/ADXL362ng/
 category=Sensors
 architectures=*


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format